### PR TITLE
Fix the build errors in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,7 +34,7 @@ jobs:
         configuration: |
           {
             "template": "#{{CHANGELOG}}\n\n## Installation\n1. Download the ScreenToImageKit.exe file\n2. Run the executable\n3. Configure your ImageKit credentials on first run\n\n## Requirements\n- Windows OS\n- ImageKit account with valid credentials",
-            "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+            "pr_template": "- ${{github.event.pull_request.title}} (#${{NUMBER}})",
             "empty_template": "- No changes"
           }
       env:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ A Python application that captures screenshots and uploads them to ImageKit.
 
    # Push the tag to GitHub
    git push origin v1.0.0
+   ```
+
+3. **Fix for Build Error**
+   - Replace the expression `${{TITLE}}` with `${{github.event.pull_request.title}}` in the GitHub Actions workflow file `.github/workflows/build-and-release.yml`.
 
 ## For Open Source Community Support
 


### PR DESCRIPTION
Fix the build error related to the unrecognized named-value 'TITLE' in the GitHub Actions workflow file.

* **README.md**
  - Add a note about the fix for the build error in the "Publishing New Releases" section.
  - Mention the correct expression `${{github.event.pull_request.title}}` to use in the GitHub Actions workflow file.

* **.github/workflows/build-and-release.yml**
  - Replace the expression `${{TITLE}}` with `${{github.event.pull_request.title}}` in line 37.

